### PR TITLE
Basic CMS fetching Playwright tests

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,6 +1,17 @@
 name: Playwright Tests (v3)
 on:
   workflow_dispatch:
+    inputs:
+      run_cms:
+        description: Run live Directus CMS tests
+        required: false
+        default: false
+        type: boolean
+      cms_base_url:
+        description: Directus base URL for CMS tests
+        required: false
+        default: https://api.serveriry.fi/
+        type: string
   push:
     branches: [ main, master ]
   pull_request:
@@ -44,6 +55,46 @@ jobs:
       if: failure()
       with:
         name: playwright-debug-artifacts
+        path: |
+          app/playwright-report/
+          app/test-results/
+        if-no-files-found: ignore
+        retention-days: 7
+
+  cms-test:
+    if: github.event_name == 'workflow_dispatch' && inputs.run_cms == true
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
+    env:
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      NUXT_API_URL: ${{ inputs.cms_base_url }}
+      CMS_BASE_URL: ${{ inputs.cms_base_url }}
+    defaults:
+      run:
+        working-directory: ./app
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install pnpm
+      uses: pnpm/action-setup@v3
+      with:
+        version: 9
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: pnpm
+        cache-dependency-path: app/pnpm-lock.yaml
+    - name: Install dependencies
+      run: |
+        pnpm install --frozen-lockfile
+        node -e "require.resolve('@oxc-parser/binding-linux-x64-gnu')"
+    - name: Run Playwright CMS tests
+      run: pnpm test:e2e:cms
+    - uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: playwright-cms-debug-artifacts
         path: |
           app/playwright-report/
           app/test-results/

--- a/app/package.json
+++ b/app/package.json
@@ -13,8 +13,9 @@
       "format": "prettier --write src/**/*.{tsx,jsx,ts,js,vue}",
       "deps:check": "npx npm-check-updates",
       "deps:update": "npx npm-check-updates -u && npm install",
-      "test:e2e": "playwright test",
-      "test:e2e:ui": "playwright test --ui"
+      "test:e2e": "playwright test --grep-invert @cms",
+      "test:e2e:ui": "playwright test --ui --grep-invert @cms",
+      "test:e2e:cms": "playwright test tests/cms-live.spec.ts --workers=1"
    },
    "dependencies": {
       "@eslint/eslintrc": "^3.3.3",

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from '@playwright/test';
-import os from 'os';
+import * as os from 'os';
 
 const isCI = !!process.env.CI;
 

--- a/app/tests/README.md
+++ b/app/tests/README.md
@@ -23,15 +23,40 @@ npx playwright install
 First start the app (dev or preview):
 
 ```
-npm run dev
+pnpm dev
 # or
-npm run build
-npm run preview
+pnpm build
+pnpm preview
 ```
 
 Then run tests:
 
 ```
-npm run test:e2e
+pnpm test:e2e
+```
+
+## Live Directus CMS tests (opt-in)
+
+CMS integration tests are tagged with `@cms` and excluded from normal runs, including CI default runs.
+
+Run them explicitly:
+
+```
+pnpm test:e2e:cms
+```
+
+Defaults used by the CMS test command:
+
+- `NUXT_API_URL` defaults to `https://api.serveriry.fi/` (from Nuxt runtime config)
+- `CMS_BASE_URL` defaults to `NUXT_API_URL` or `https://api.serveriry.fi/`
+
+Override these env vars if your local Directus is on a different URL/port.
+
+PowerShell example for local Directus:
+
+```
+$env:NUXT_API_URL='http://127.0.0.1:30001/'
+$env:CMS_BASE_URL='http://127.0.0.1:30001'
+pnpm test:e2e:cms
 ```
 

--- a/app/tests/cms-live.spec.ts
+++ b/app/tests/cms-live.spec.ts
@@ -1,0 +1,115 @@
+import { test, expect } from '@playwright/test';
+
+const CMS_BASE_URL = process.env.CMS_BASE_URL || process.env.NUXT_API_URL || 'https://api.serveriry.fi/';
+const DIRECTUS_EVENTS_PATH = '/items/tapahtuma';
+const FALLBACK_EVENT_TITLE = 'Serveri ry:n 35-vuotis vuosijuhlat';
+const APP_BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
+
+type DirectusEvent = {
+  id?: string | number;
+  fi_otsikko?: string;
+  en_otsikko?: string;
+};
+
+type LandingPageContent = {
+  fi_long_desc?: string;
+  en_long_desc?: string;
+};
+
+function normalizeText(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function getAnchorSnippet(value: string, marker: string): string {
+  const normalized = normalizeText(value);
+  const markerIndex = normalized.indexOf(marker);
+  if (markerIndex === -1) {
+    return marker;
+  }
+  return normalized.slice(markerIndex, markerIndex + 80).trim();
+}
+
+async function setLocaleCookie(page: import('@playwright/test').Page, locale: 'fi' | 'en') {
+  await page.context().addCookies([
+    {
+      name: 'i18n_redirected',
+      value: locale,
+      url: APP_BASE_URL,
+    },
+  ]);
+}
+
+test.describe('@cms Directus live CMS integration', () => {
+  test('Directus events endpoint responds', async ({ request }) => {
+    test.setTimeout(90_000);
+
+    const endpoint = new URL(`${DIRECTUS_EVENTS_PATH}?limit=1`, CMS_BASE_URL).toString();
+    const response = await request.get(endpoint);
+    expect(response.ok()).toBeTruthy();
+
+    const payload = await response.json();
+    expect(payload).toHaveProperty('data');
+    expect(Array.isArray(payload.data)).toBeTruthy();
+  });
+
+  test('events page renders content from live CMS', async ({ page }) => {
+    test.setTimeout(90_000);
+
+    const endpoint = new URL(`${DIRECTUS_EVENTS_PATH}?limit=20`, CMS_BASE_URL).toString();
+    const response = await page.request.get(endpoint);
+    expect(response.ok()).toBeTruthy();
+
+    const payload = (await response.json()) as { data?: DirectusEvent[] };
+    const cmsEvents = payload.data ?? [];
+    expect(cmsEvents.length).toBeGreaterThan(0);
+
+    const sampleEvent = cmsEvents.find((item) => item.id !== undefined && (item.fi_otsikko?.trim() || item.en_otsikko?.trim()));
+    expect(sampleEvent).toBeDefined();
+
+    const expectedId = String(sampleEvent!.id);
+    const expectedTitle = (sampleEvent!.fi_otsikko?.trim() || sampleEvent!.en_otsikko?.trim()) as string;
+
+    await page.goto('/yhdistys/tapahtumat', { waitUntil: 'networkidle' });
+    await expect(page.locator('h1.custom-page-title').first()).toBeVisible();
+
+    await expect(page.getByText(FALLBACK_EVENT_TITLE)).toHaveCount(0);
+
+    const eventLink = page.locator(`a[href="/yhdistys/tapahtuma/${expectedId}"]`).first();
+    await expect(eventLink).toBeVisible();
+    await expect(eventLink.locator('h2.card-header')).toContainText(expectedTitle);
+  });
+
+  test('landing page long description is rendered from CMS (FI and EN)', async ({ page }) => {
+    test.setTimeout(90_000);
+
+    const endpoint = new URL('items/LandingPage', CMS_BASE_URL).toString();
+    const response = await page.request.get(endpoint);
+    expect(response.ok()).toBeTruthy();
+
+    const payload = (await response.json()) as { data?: LandingPageContent | LandingPageContent[] };
+    const landingData = Array.isArray(payload.data) ? payload.data[0] : payload.data;
+    expect(landingData).toBeDefined();
+
+    const fiLongDesc = normalizeText(landingData?.fi_long_desc ?? '');
+    const enLongDesc = normalizeText(landingData?.en_long_desc ?? '');
+
+    expect(fiLongDesc.length).toBeGreaterThan(20);
+    expect(enLongDesc.length).toBeGreaterThan(20);
+    // Verify that landing page long descriptions are fetched from cms and contain text "Server"
+    expect(fiLongDesc).toContain('Server');
+    expect(enLongDesc).toContain('Server');
+
+    const fiSnippet = getAnchorSnippet(fiLongDesc, 'Server');
+    const enSnippet = getAnchorSnippet(enLongDesc, 'Server');
+
+    await setLocaleCookie(page, 'fi');
+    await page.goto('/', { waitUntil: 'networkidle' });
+    await expect(page.locator('.rich-text').first()).toContainText(fiSnippet);
+    await expect(page.getByText('Miksi serverit on niin kuumia?')).toHaveCount(0);
+
+    await setLocaleCookie(page, 'en');
+    await page.goto('/en', { waitUntil: 'networkidle' });
+    await expect(page.locator('.rich-text').first()).toContainText(enSnippet);
+    await expect(page.getByText('Why are the servers so hot?')).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
Tests for cms content fetching. Currently tests landing page and events page. Tests are not automatically run in github actions as they are a bit slow, but they can be run there manually.
<img width="815" height="132" alt="kuva" src="https://github.com/user-attachments/assets/9a786eed-d94f-4b63-a68e-99551542169f" />
