### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,6 +4,8 @@ on:
     branches: [ main, master ]
   pull_request:
     branches: [ main, master ]
+permissions:
+  contents: read
 jobs:
   test:
     timeout-minutes: 60


### PR DESCRIPTION
Potential fix for [https://github.com/serveri/new.serveriry.fi.nuxtjs/security/code-scanning/4](https://github.com/serveri/new.serveriry.fi.nuxtjs/security/code-scanning/4)

Add an explicit `permissions` block at the workflow root so it applies to all jobs in this workflow (currently only `test`). The minimal safe baseline for this file is:

- `contents: read`

This preserves existing functionality (checkout and read-only repo access) while ensuring the token is not granted broader default permissions.  
Edit `.github/workflows/playwright.yml` by inserting the `permissions` block between the `on:` trigger section and `jobs:`.

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
